### PR TITLE
Mssql migration fix

### DIFF
--- a/User-Data Store Migration/README.md
+++ b/User-Data Store Migration/README.md
@@ -32,9 +32,19 @@ The tool is designed to help a database administrator generate the correct scrip
    sqlite3 ./linkurious/data/server/database.sqlite .dump > export.sql
    ```
 2. Put the `export.sql` file in the same directory of the `dump-converter.py` python script
-3. Run the program to generate a new SQL import script (example for MySQL):
+3. Run the program to generate a new SQL import script:
+   
+   example for MySQL
    ```shell
    python3 dump-converter.py --dialect mysql -o export-parsed.sql export.sql > select-queries.sql
+   ```
+   example for MariaDB
+   ```shell
+   python3 dump-converter.py --dialect mariadb -o export-parsed.sql export.sql > select-queries.sql
+   ```
+   example for Microsoft SQL Server
+   ```shell
+   python3 dump-converter.py --dialect mssql -o export-parsed.sql export.sql > select-queries.sql
    ```
 4. The program will generate two files:
    - export-parsed.sql : the new SQL import file to be used instead of the initial one
@@ -43,9 +53,19 @@ The tool is designed to help a database administrator generate the correct scrip
 6. Configure Linkurious Enterprise to point the new Database (refer to the correct version of the [documentation](https://doc.linkurio.us) in case of doubts)
 7. Start Linkurious Enterprise
 8. As soon as it starts properly (you can see the application, regardless the connection error to the graph database), stop it.
-9. Run the new script in your system to import data (example for MySQL):
+9. Run the new script in your system to import data:
+   
+   example for MySQL
    ```shell
    mysql -u MY_MYSQL_USER -p -h 127.0.0.1 linkurious < export-parsed.sql
+   ```
+   example for MariaDB
+   ```shell
+   mariadb -u MY_MYSQL_USER -p -h 127.0.0.1 linkurious < export-parsed.sql
+   ```
+   example for Microsoft SQL Server
+   ```shell
+   sqlcmd -U MY_MYSQL_USER -H 127.0.0.1 -d linkurious -i export-parsed.sql
    ```
 10. After the import script is executed successfully you can start again Linkurious Enterprise and accessing all the previous data
 

--- a/User-Data Store Migration/README.md
+++ b/User-Data Store Migration/README.md
@@ -53,15 +53,15 @@ The tool is designed to help a database administrator generate the correct scrip
 6. Configure Linkurious Enterprise to point the new Database (refer to the correct version of the [documentation](https://doc.linkurio.us) in case of doubts)
 7. Start Linkurious Enterprise
 8. As soon as it starts properly (you can see the application, regardless the connection error to the graph database), stop it.
-9. Run the new script in your system to import data:
+9. Run the new script in your system to import data (since the system uses **unicode characters**, be careful to the encoding):
    
    example for MySQL
    ```shell
-   mysql -u MY_MYSQL_USER -p -h 127.0.0.1 linkurious < export-parsed.sql
+   mysql -u MY_MYSQL_USER -p -h 127.0.0.1 --default-character-set=utf8mb4 linkurious < export-parsed.sql
    ```
    example for MariaDB
    ```shell
-   mariadb -u MY_MYSQL_USER -p -h 127.0.0.1 linkurious < export-parsed.sql
+   mariadb -u MY_MYSQL_USER -p -h 127.0.0.1 --default-character-set=utf8mb4 linkurious < export-parsed.sql
    ```
    example for Microsoft SQL Server
    ```shell

--- a/User-Data Store Migration/README.md
+++ b/User-Data Store Migration/README.md
@@ -108,11 +108,11 @@ In case of migration from MySQL server instead of Sqlite, use the following proc
 
 1. Add the `lke_export` stored procedure provided in the `mysql_export_sp.sql` script
    ```shell
-   mysql -u MY_MYSQL_USER -p -h 127.0.0.1 -e linkurious < mysql_export_sp.sql
+   mysql -u MY_MYSQL_USER -p -h 127.0.0.1 linkurious < mysql_export_sp.sql
    ```
 1. Execute the store procedure, note the presence of `-NBr` parameters (mandatory to avoid format issues)
    ```shell
-   mysql -NBr -u MY_MYSQL_USER -p -h 127.0.0.1 -e "call lke_export" linkurious > export.sql
+   mysql -NBr -u MY_MYSQL_USER -p -h 127.0.0.1 --default-character-set=utf8mb4 -e "call lke_export" linkurious > export.sql
    ```
 
 Follow the rest of the standard procedure for Sqlite migration.

--- a/User-Data Store Migration/README.md
+++ b/User-Data Store Migration/README.md
@@ -48,9 +48,10 @@ The tool is designed to help a database administrator generate the correct scrip
    ```shell
    python3 dump-converter.py --dialect mssql -d schema.json -o export-parsed.sql export.sql > select-queries.sql
    ```
-4. The program will generate two files:
-   - export-parsed.sql : the new SQL import file to be used instead of the initial one
-   - select-queries.sql : a script containing the `select` queries for all the tables found in the initial script. It can be useful for debugging / crosscheck purposes.
+4. The program will generate three files:
+   - `export-parsed.sql` : the new SQL import file to be used instead of the initial one
+   - `select-queries.sql` : a script containing the `select` queries for all the tables found in the initial script. It can be useful for debugging / crosscheck purposes.
+   - `schema.json` : the schema discovered in the input script, useful to resolve eventual schema conflicts (see later for more details)
 5. Setup your external database server and create an empty database
 6. Configure Linkurious Enterprise to point the new Database (refer to the correct version of the [documentation](https://doc.linkurio.us) in case of doubts)
 7. Start Linkurious Enterprise
@@ -106,13 +107,13 @@ Repeat the above steps as many time as required to to fix all the mismatch.
 In case of migration from MySQL server instead of Sqlite, use the following procedure to create the `export.sql` file.
 
 1. Add the `lke_export` stored procedure provided in the `mysql_export_sp.sql` script
-```shell
-mysql -u MY_MYSQL_USER -p -h 127.0.0.1 -e linkurious < mysql_export_sp.sql
+   ```shell
+   mysql -u MY_MYSQL_USER -p -h 127.0.0.1 -e linkurious < mysql_export_sp.sql
    ```
 1. Execute the store procedure, note the presence of `-NBr` parameters (mandatory to avoid format issues)
    ```shell
    mysql -NBr -u MY_MYSQL_USER -p -h 127.0.0.1 -e "call lke_export" linkurious > export.sql
-```
+   ```
 
 Follow the rest of the standard procedure for Sqlite migration.
 

--- a/User-Data Store Migration/README.md
+++ b/User-Data Store Migration/README.md
@@ -33,6 +33,9 @@ The tool is designed to help a database administrator generate the correct scrip
    ```
 
    The tool has been tested to support also migration from MySQL (see the section [How to migrate from MySQL](#how-to-migrate-from-mysql)).
+
+   > /!\ Minimum requirement sqlite3 v3.19.0. Earlier versions will not export properly multiline data (e.g. queries or descriptions containing multiple lines)
+
 2. Put the `export.sql` file in the same directory of the `dump-converter.py` python script
 3. Run the program to generate a new SQL import script:
    

--- a/User-Data Store Migration/README.md
+++ b/User-Data Store Migration/README.md
@@ -31,6 +31,8 @@ The tool is designed to help a database administrator generate the correct scrip
    ```shell
    sqlite3 ./linkurious/data/server/database.sqlite .dump > export.sql
    ```
+
+   The tool has been tested to support also migration from MySQL (see the section [How to migrate from MySQL](#how-to-migrate-from-mysql)).
 2. Put the `export.sql` file in the same directory of the `dump-converter.py` python script
 3. Run the program to generate a new SQL import script:
    
@@ -98,6 +100,21 @@ the tool has already generated a `schema.json` file containing the structure ide
    ```
 
 Repeat the above steps as many time as required to to fix all the mismatch.
+
+
+## How to migrate from MySQL
+In case of migration from MySQL server instead of Sqlite, use the following procedure to create the `export.sql` file.
+
+1. Add the `lke_export` stored procedure provided in the `mysql_export_sp.sql` script
+```shell
+mysql -u MY_MYSQL_USER -p -h 127.0.0.1 -e linkurious < mysql_export_sp.sql
+   ```
+1. Execute the store procedure, note the presence of `-NBr` parameters (mandatory to avoid format issues)
+   ```shell
+   mysql -NBr -u MY_MYSQL_USER -p -h 127.0.0.1 -e "call lke_export" linkurious > export.sql
+```
+
+Follow the rest of the standard procedure for Sqlite migration.
 
 
 ## How to customize the tool

--- a/User-Data Store Migration/README.md
+++ b/User-Data Store Migration/README.md
@@ -67,7 +67,7 @@ The tool is designed to help a database administrator generate the correct scrip
    ```
    example for Microsoft SQL Server
    ```shell
-   sqlcmd -U MY_MYSQL_USER -H 127.0.0.1 -d linkurious -i export-parsed.sql
+   sqlcmd -U MY_MYSQL_USER -S 127.0.0.1 -d linkurious -i export-parsed.sql
    ```
 
    > /!\ In case you get errors related to the schema definition, see the section [How to manage schema conflicts](#how-to-handle-schema-conflicts)

--- a/User-Data Store Migration/dump-converter.py
+++ b/User-Data Store Migration/dump-converter.py
@@ -152,8 +152,9 @@ def initialize(out):
         replace_rules.append((True, r"^CREATE TABLE `(?P<name>[^`]*)`.*$", ("TRUNCATE TABLE " + NAME_TEMPLATE + ";") % ("{1}"), 1, getStructureInfoCreate, True))
     elif __dialect__ == "mssql":
         NAME_TEMPLATE = "[%s]"
-        pre.append("EXEC sp_MSforeachtable 'ALTER TABLE ? NOCHECK CONSTRAINT all';")
-        post.append("EXEC sp_MSforeachtable 'ALTER TABLE ? WITH CHECK CHECK CONSTRAINT all';")
+        pre.append("declare @query varchar(max);");
+        pre.append("select @query = coalesce(@query + ' ' + 'ALTER TABLE [' + name + '] NOCHECK CONSTRAINT all;', 'ALTER TABLE [' + name + '] NOCHECK CONSTRAINT all;') from sys.tables; exec(@query);")
+        post.append("select @query = coalesce(@query + ' ' + 'ALTER TABLE [' + name + '] WITH CHECK CHECK CONSTRAINT all;', 'ALTER TABLE [' + name + '] WITH CHECK CHECK CONSTRAINT all;') from sys.tables; exec(@query);")
         post.append("go")
 
         replace_rules.append((True, r"^START TRANSACTION;\s*$", "BEGIN TRANSACTION;", 0, None, True))

--- a/User-Data Store Migration/dump-converter.py
+++ b/User-Data Store Migration/dump-converter.py
@@ -56,7 +56,7 @@ def extractListOfValues(inputStr):
 
         if in_string:
             if c == "'":
-                    escape_quote = not escape_quote
+                escape_quote = not escape_quote
             
             value_buffer += c
         else:

--- a/User-Data Store Migration/dump-converter.py
+++ b/User-Data Store Migration/dump-converter.py
@@ -96,7 +96,7 @@ def injectStructureInfoInsertInto(match, replace):
 
     statement = match.group(0)
     match = re.match(r"^\s*INSERT\s+INTO\s*(?:(?P<quote>[\"` ])(?P<name>.*?)(?P=quote)).*VALUES\s*\((?P<values>.*)\).*$", statement)
-    assert match, "Error while parsing an Insert Statement"
+    assert match, "Error while parsing an Insert Statement: `%s`" % (statement)
     
     last_header = match.group("name")
     headers = table_header.get(last_header, None)
@@ -106,7 +106,7 @@ def injectStructureInfoInsertInto(match, replace):
 
         if __out_schema__:
             out_headers = __out_schema__.get(last_header, None)
-            assert out_headers, "Error while creating an Insert Statement, mismatch between input data and schema"
+            assert out_headers, "Error while creating an Insert Statement, mismatch between input data and schema: `%s`" % (statement)
             out_headers = set(out_headers)
             for i in range(len(in_headers) - 1, -1, -1):
                 if not in_headers[i] in out_headers:
@@ -116,7 +116,7 @@ def injectStructureInfoInsertInto(match, replace):
         headers = ([NAME_TEMPLATE % (x) for x in in_headers], entries_to_skip if len(entries_to_skip) > 0 else None)
         table_header[last_header] = headers
 
-    assert headers, "Error while creating an Insert Statement, no table definition found"
+    assert headers, "Error while creating an Insert Statement, no table definition found for `%s`" % (last_header)
 
     values = extractListOfValues(match.group("values"))
     
@@ -124,7 +124,7 @@ def injectStructureInfoInsertInto(match, replace):
         for pos in headers[1]:
             del values[pos]
 
-    assert len(headers[0]) == len(values), "Error while creating an Insert Statement, mismatch between number of headers and number of values"
+    assert len(headers[0]) == len(values), "Error while creating an Insert Statement, mismatch between number of headers and number of values for table `%s`: %s" % (last_header, statement)
     statement = ("INSERT INTO " + NAME_TEMPLATE + "(%s) VALUES(%s);\n") % (last_header, ",".join(headers[0]), ",".join(values))
     
     return statement

--- a/User-Data Store Migration/mysql_export_sp.sql
+++ b/User-Data Store Migration/mysql_export_sp.sql
@@ -1,0 +1,100 @@
+DELIMITER $$
+DROP PROCEDURE IF EXISTS lke_export;
+CREATE PROCEDURE lke_export()
+BEGIN
+	DECLARE done INT DEFAULT FALSE;
+	DECLARE tableName TEXT DEFAULT "";
+	
+	DECLARE cursor_tables CURSOR FOR
+	SELECT table_name
+	FROM information_schema.tables
+	WHERE
+		table_schema = DATABASE()
+		AND table_type = 'BASE TABLE'
+	ORDER BY table_name;
+	
+	DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+	
+	SET SESSION group_concat_max_len = @@max_allowed_packet;
+	-- buffer to be exported to file
+	
+	OPEN cursor_tables;
+
+	SELECT 'START TRANSACTION;';
+	
+	getTables: LOOP
+		
+		FETCH cursor_tables INTO tableName;
+		IF done THEN 
+			LEAVE getTables;
+		END IF;
+		
+		-- export single line CREATE TABLE statement
+		SELECT CONCAT(
+			'CREATE TABLE ',
+			'`',
+			tableName,
+			'` (',
+			GROUP_CONCAT(CONCAT('`', column_name, '` ', column_type) SEPARATOR ','),
+			');'
+		)
+		FROM
+			information_schema.columns
+		WHERE
+			table_schema = DATABASE()
+			AND table_name = tableName
+		ORDER BY ordinal_position;
+		
+		-- dynamic building of value's list for the INSERT INTO statement
+		SELECT
+			GROUP_CONCAT(
+				CONCAT(
+					-- manage null values
+					'IFNULL(',
+					CASE
+						WHEN NOT collation_name IS NULL THEN
+							-- value is a string: add quotes and replace eventual \n to keep single line instruction
+							CONCAT(
+								'\n\t\tCASE WHEN INSTR(`', column_name, '`, ''\\n'') > 0',
+								'\n\t\t\tTHEN CONCAT(''REPLACE('''''', REPLACE(REPLACE(', CONCAT('`', column_name, '`'), ', ''\\n'', ''\\\\n''), '''''''', ''''''''''''), '''''',''''\\\\n'''',char(10))'')',
+								'\n\t\t\tELSE CONCAT('''''''', REPLACE(', CONCAT('`', column_name, '`'), ', '''''''', ''''''''''''), '''''''')',
+								'\n\t\tEND'
+							)
+						WHEN data_type = 'datetime' or data_type = 'date' THEN
+							-- date/datime: add quotes
+							CONCAT('CONCAT('''''''',', CONCAT('`', column_name, '`'), ','''''''')')
+						ELSE
+							-- other types: no quotes needed
+							CONCAT('`', column_name, '`')
+							
+					END,
+					', ''null'')'
+				)
+				SEPARATOR ', '','',\n\t'
+			)
+		INTO @values
+		FROM
+			information_schema.columns
+		WHERE
+			table_schema = DATABASE()
+			AND table_name = tableName
+		ORDER BY ordinal_position;
+
+		-- SELECT @values; -- DEBUG
+		
+		-- dynamic building of the INSERT INTO statement
+		SET @insert_statement = CONCAT('CONCAT(''INSERT INTO `', tableName, '` VALUES ('',\n\t', @values , ',\n'');'')');
+		-- export single line INSERT INTO statement for each line in the table
+		SET @q1 = CONCAT('SELECT\n\n', @insert_statement, '\n\nFROM `', tableName, '`;');
+		
+		-- SELECT @q1; -- DEBUG
+		PREPARE stmt FROM @q1;
+		EXECUTE stmt;
+		DEALLOCATE PREPARE stmt;
+	
+	END LOOP getTables;
+	CLOSE cursor_tables;
+
+	SELECT 'COMMIT;';
+END$$
+DELIMITER ;


### PR DESCRIPTION
Test environment:
- Python 2.7.16
- Python 3.7.4
- MySQL 5.7.27 (homebrew)
- MySQL 8.0.20 (Community - docker)
- Mariadb 10.4.6 (docker)
- Microsoft SQL Server 2017 (RTM-CU13) (KB4466404) - 14.0.3048.4 (docker - linux)
- Azure SQL (instance created around June 2020)

Tested migration scenario:
- Sqlite -> MySQL v5
- Sqlite -> MySQL v8 (no crosscheck with LKE)
- Sqlite -> Mariadb
- Sqlite -> Microsoft SQL Server
- Sqlite -> Azure SQL
- MySQL v5/v8 -> MS SQL / Azure SQL
- Mariadb -> MS SQL / Azure SQL

Testing focus:
- Consistent format among import / export through command line tool
- Consistent unicode characters (internal icon styles)
- Consistent parsing of special characters in strings (especially single/double quotes, new lines)
- Consistent results for big tables (visualization with ~2k nodes + ~2k edges)

Main differences:
- Tables order in the export script
- Date time values may differ by a second due different precisions among different databases
