### PR TITLE
Clarify the impact of the embedded Elasticsearch v8.13.4 update

### DIFF
--- a/Customer Support Procedures/LKE-v4.1-migration.md
+++ b/Customer Support Procedures/LKE-v4.1-migration.md
@@ -138,11 +138,17 @@ We have updated our internal dependencies to new major releases to offer up to d
 
 ***Benefits:***
 
-- Enhanced Security
+Enhanced Security.
 
 ***Impacts:***
 
-- None
+As part of these security updates, the embedded Elasticsearch has been updated to v8.13.4.
+
+Due to this update, the data-sources that use the "Embedded Elasticsearch" search provider will have
+full-text search disabled, upon upgrading Linkurious.
+
+To re-enable full-text search, you will need to re-index the impacted data-sources. This can be done
+in one click from the data-source configuration page.
 
 # Dropped Support section
 


### PR DESCRIPTION
This pull request clarifies the impact of the embedded Elasticsearch v8.13.4 update, in the guidelines of the v4.1 migration.

It repeats what's already stated in the breaking changes section of the v4.1 changelog, for the sake of improved visibility.