### PR TITLE
Add compatibility for Linkurious Enterprise 4.2

### DIFF
--- a/compatibility-matrix/compatibility-matrix.md
+++ b/compatibility-matrix/compatibility-matrix.md
@@ -10,9 +10,10 @@
 | [Azure Cosmos DB][d]       |      Yes      |      Yes        |      Yes        |       Yes       |       Yes       |         Yes        |
 | [Memgraph][e]              |      No       | 2.4 - 2.7[^2]   | 2.4 - 2.7[^2]   |  2.4 - 2.7[^2]  | 2.4 - 2.16[^2]  |    2.4 - 3.1[^2]   |
 | [Amazon Neptune][f]        |      No       |   1.2.0[^2]     |   1.2.0[^2]     |    1.2.0[^2]    |    1.3.0[^2]    |      1.3.0[^2]     |
-| [MySQL][g]                 |   5.6 - 8.0   |   5.6 - 8.0     |   5.6 - 8.0     |    5.6 - 8.0    |       8.0       |      8.0 - 8.4     |
-| [MariaDB][h]               |  10.1 - 10.5  |  10.1 - 10.5    |  10.1 - 10.5    |   10.1 - 10.5   |  10.6 - 10.11   |     10.6 - 11.4    |
-| [Microsoft SQL Server][i]  |  2014 - 2019  |  2014 - 2019    |  2014 - 2019    |   2014 - 2022   |   2014 - 2022   |     2014 - 2022    |
+| [Google Spanner][g]        |      No       |       No        |       No        |       No        |     No[^3]      |         Yes        |
+| [MySQL][h]                 |   5.6 - 8.0   |   5.6 - 8.0     |   5.6 - 8.0     |    5.6 - 8.0    |       8.0       |      8.0 - 8.4     |
+| [MariaDB][i]               |  10.1 - 10.5  |  10.1 - 10.5    |  10.1 - 10.5    |   10.1 - 10.5   |  10.6 - 10.11   |     10.6 - 11.4    |
+| [Microsoft SQL Server][j]  |  2014 - 2019  |  2014 - 2019    |  2014 - 2019    |   2014 - 2022   |   2014 - 2022   |     2014 - 2022    |
 
 [a]: https://neo4j.com/
 [b]: https://neo4j.com/aura/
@@ -20,9 +21,11 @@
 [d]: https://azure.microsoft.com/en-us/products/cosmos-db
 [e]: https://memgraph.com/
 [f]: https://aws.amazon.com/neptune/
-[g]: https://www.mysql.com/
-[h]: https://mariadb.org/
-[i]: https://www.microsoft.com/en-us/sql-server/
+[g]: https://cloud.google.com/spanner
+[h]: https://www.mysql.com/
+[i]: https://mariadb.org/
+[j]: https://www.microsoft.com/en-us/sql-server/
 
 [^1]: [Incremental indexing](https://doc.linkurious.com/admin-manual/4.0/incremental-indexing/) on Neo4j 5.x clusters is supported only if Linkurious Enterprise is 4.0.4 or higher and Neo4j is 5.4.0 or higher
 [^2]: No support for [incremental indexing](https://doc.linkurious.com/admin-manual/4.0/incremental-indexing/) with Elasticsearch
+[^3]: Google Spanner is supported in beta on Linkurious Enterprise 4.1.13 and higher


### PR DESCRIPTION
### Description

* Remove Linkurious Enterprise 3.0 from the compatibility matrix.

* Add Linkurious Enterprise 4.2 to the compatibility matrix:
  * Add support for Neo4j 2025.x
  * Add support for Memgraph 3.1
  * Add support for MySQL 8.4
  * Add support for MariaDB 11.4
  * Remove support for Elasticsearch 7

### Related Jira issues
* https://linkurious.atlassian.net/browse/LKE-9982
* https://linkurious.atlassian.net/browse/LKE-13006
* https://linkurious.atlassian.net/browse/LKE-13007
* https://linkurious.atlassian.net/browse/LKE-13008
* https://linkurious.atlassian.net/browse/LKE-13091

### Preview

![preview](https://github.com/user-attachments/assets/7dab5ffb-69dd-4cd0-a562-f81486acd99b)


